### PR TITLE
fix issue with PromiseRejectionHandledWarning

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -1,7 +1,7 @@
 var q = require('q');
 
 /**
- * Wrapper arround MongoDB Cursor to convert results to Models. 
+ * Wrapper around MongoDB Cursor to convert results to Models.
  * @class
  * @param {object} cursor - MongoDB cursor object
  * @param {function} factory - Factory function used to create Models based on document from cursor.
@@ -13,7 +13,7 @@ var Cursor = function (cursor, factory) {
 
 /**
  * Iterates over cursor and executes the iterator for each model returned.
- * @param {function} iterator 
+ * @param {function} iterator
  * @returns {Promise}
  * @see {@link http://mongodb.github.io/node-mongodb-native/3.0/api/Cursor.html#forEach}
  */

--- a/lib/model.js
+++ b/lib/model.js
@@ -345,7 +345,8 @@ function _create (data, definition) {
     var obj = this.toObject();
     var before = q.resolve(obj);
     if ('function' === typeof this.beforeSave) {
-      before = q(this.beforeSave.apply(obj)).then(function () { return obj; });
+      before = q.fcall(() => { return this.beforeSave.apply(obj); })
+        .then(function () { return obj; });
     }
     return before
       .then(function (obj) {
@@ -399,7 +400,7 @@ function _create (data, definition) {
     var collection = definition.collection;
     var query = { _id: this._id, _etag: this._etag };
     var before = 'function' === typeof this.beforeRemove ?
-      q(this.beforeRemove()) : q.resolve();
+      q.fcall(() => { return this.beforeRemove(); }) : q.resolve();
     return before.then(function () {
       debug('removing ' + JSON.stringify(query) + ' in ' + collection);
       return db.remove(collection, query)


### PR DESCRIPTION
if beforeSave or beforeRemove returns a rejected promise synchronously (for example, if beforeSave is marked as async, but throws an exception), because the promise chain doesn't have handlers on it yet, node will first complain about an unhandled promise rejection (and actually call the unhandled promise rejection handler) - and then it will realize that error handlers were attached and print out “PromiseRejectionHandledWarning: Promise rejection was handled asynchronously”.

The printing out of stuff, whatever - but the fact the unhandled promise rejection handler fires off is problematic.